### PR TITLE
New method 'boundary' for creating the building connection point

### DIFF
--- a/dhnx/gistools/connect_points.py
+++ b/dhnx/gistools/connect_points.py
@@ -211,15 +211,17 @@ def create_object_connections(points, lines, tol_distance=1):
         if n_p in supply_line_points:
             # case that nearest point is a line ending
 
-            logging.info(
+            logging.debug(
                 'Connect buildings... id {}: '
                 'Connected to supply line ending (nearest point)'.format(index)
             )
 
             con_line = LineString([n_p, house_geo])
 
-            conn_lines = pd.concat([conn_lines, gpd.GeoDataFrame(
-                geometry=[con_line], crs=lines.crs)], ignore_index=True)
+            conn_lines = pd.concat(
+                [gpd.GeoDataFrame(conn_lines, crs=lines.crs),
+                 gpd.GeoDataFrame(geometry=[con_line], crs=lines.crs)],
+                ignore_index=True)
 
         else:
 
@@ -229,25 +231,29 @@ def create_object_connections(points, lines, tol_distance=1):
                 # line is split, no line ending is close to the nearest point
                 # this also means the original supply line needs to be deleted
 
-                logging.info(
+                logging.debug(
                     'Connect buildings... id {}: Supply line split'.format(index))
 
                 con_line = LineString([n_p, house_geo])
 
-                conn_lines = pd.concat([conn_lines, gpd.GeoDataFrame(
-                    geometry=[con_line], crs=lines.crs)], ignore_index=True)
+                conn_lines = pd.concat(
+                    [gpd.GeoDataFrame(conn_lines, crs=lines.crs),
+                     gpd.GeoDataFrame(geometry=[con_line], crs=lines.crs)],
+                    ignore_index=True)
 
                 lines.drop([line_index], inplace=True)
 
-                lines = pd.concat([lines, gpd.GeoDataFrame(
-                    geometry=[LineString([supply_line_p0, n_p]),
-                              LineString([n_p, supply_line_p1])],
-                    crs=lines.crs)], ignore_index=True)
+                lines = pd.concat(
+                    [gpd.GeoDataFrame(lines, crs=lines.crs),
+                     gpd.GeoDataFrame(geometry=[
+                         LineString([supply_line_p0, n_p]),
+                         LineString([n_p, supply_line_p1])], crs=lines.crs)],
+                    ignore_index=True)
 
             else:
                 # case that one or both line endings are closer than tolerance
                 # thus, the next line ending is chosen
-                logging.info(
+                logging.debug(
                     'Connect buildings... id {}: Connected to Supply line '
                     'ending due to tolerance'.format(index))
 
@@ -255,8 +261,10 @@ def create_object_connections(points, lines, tol_distance=1):
 
                 con_line = LineString([conn_point, house_geo])
 
-                conn_lines = pd.concat([conn_lines, gpd.GeoDataFrame(
-                    geometry=[con_line], crs=lines.crs)], ignore_index=True)
+                conn_lines = pd.concat(
+                    [gpd.GeoDataFrame(conn_lines, crs=lines.crs),
+                     gpd.GeoDataFrame(geometry=[con_line], crs=lines.crs)],
+                    ignore_index=True)
 
     logging.info('Connection of buildings completed.')
 

--- a/dhnx/optimization/add_components.py
+++ b/dhnx/optimization/add_components.py
@@ -151,7 +151,7 @@ def add_sources(on, it, c, labels, nodes, busd):
 
         # add timeseries data if present
         if ts_status:
-            ts_key = labels['l_4'].split('-')[1] + '_' + labels['l_2']
+            ts_key = labels['l_4'].split('-', 1)[1] + '_' + labels['l_2']
             for col in ts.columns.values:
                 if col.split('.')[0] == ts_key:
                     outflow_args[col.split('.')[1]] = ts[col].values
@@ -195,7 +195,7 @@ def add_demand(it, labels, series, nodes, busd):
         # set static inflow values
         inflow_args = {'nominal_value': de['nominal_value'],
                        'fix': series['heat_flow'][
-                           labels['l_4'].split('-')[1]].values}
+                           labels['l_4'].split('-', 1)[1]].values}
 
         # create
         nodes.append(

--- a/dhnx/optimization/optimization_models.py
+++ b/dhnx/optimization/optimization_models.py
@@ -144,26 +144,26 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
 
         for p, q in self.thermal_network.components['pipes'].iterrows():
 
-            if (q['from_node'].split('-')[0] == "consumers") and (
-                    q['to_node'].split('-')[0] == "consumers"):
+            if (q['from_node'].split('-', 1)[0] == "consumers") and (
+                    q['to_node'].split('-', 1)[0] == "consumers"):
 
                 raise ValueError(
                     ""
                     "Pipe id {} goes from consumer to consumer. This is not "
                     "allowed!".format(p))
 
-            if (q['from_node'].split('-')[0] == "producers") and (
-                    q['to_node'].split('-')[0] == "producers"):
+            if (q['from_node'].split('-', 1)[0] == "producers") and (
+                    q['to_node'].split('-', 1)[0] == "producers"):
 
                 raise ValueError(
                     ""
                     "Pipe id {} goes from producers to producers. "
                     "This is not allowed!".format(p))
 
-            if ((q['from_node'].split('-')[0] == "producers") and (
-                    q['to_node'].split('-')[0] == "consumers")) or ((
-                        q['from_node'].split('-')[0] == "consumers") and (
-                            q['to_node'].split('-')[0] == "producers")):
+            if ((q['from_node'].split('-', 1)[0] == "producers") and (
+                    q['to_node'].split('-', 1)[0] == "consumers")) or ((
+                        q['from_node'].split('-', 1)[0] == "consumers") and (
+                            q['to_node'].split('-', 1)[0] == "producers")):
 
                 raise ValueError(
                     ""
@@ -171,19 +171,20 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                     "to consumers, or vice versa. This is not allowed!"
                     "".format(p))
 
-            if (q['from_node'].split('-')[0] == "forks") and (
-                    q['to_node'].split('-')[0] == "consumers"):
+            if (q['from_node'].split('-', 1)[0] == "forks") and (
+                    q['to_node'].split('-', 1)[0] == "consumers"):
 
-                cons_id = q['to_node'].split('-')[1]
+                cons_id = q['to_node'].split('-', 1)[1]
 
                 if cons_id not in ids_consumers:
                     raise ValueError(
                         ""
-                        "The consumer of pipe id {} does not exist!".format(p))
+                        "The consumer {} of pipe id {} does not exist!"
+                        .format(cons_id, p))
 
         pipe_to_cons_ids = list(self.thermal_network.components['pipes']['to_node'].values)
-        pipe_to_cons_ids = [x.split('-')[1] for x in pipe_to_cons_ids
-                            if x.split('-')[0] == 'consumers']
+        pipe_to_cons_ids = [x.split('-', 1)[1] for x in pipe_to_cons_ids
+                            if x.split('-', 1)[0] == 'consumers']
 
         for id in list(self.thermal_network.components['consumers'].index):
             if id not in pipe_to_cons_ids:

--- a/docs/optimization_models.rst
+++ b/docs/optimization_models.rst
@@ -295,7 +295,7 @@ everybody is free to choose his own units (energy, mass flow, etc.).
   Recommended to use with `nonconvex` is `True`.
 * **cap_max**: Maximum installable capacity (e.g. [kW]).
 * **cap_min**: Minimum installable capacity (e.g. [kW]). Note that there is a difference if a
-  *nonconvex* investment is applied (see `oemof-solph documentation <https://oemof-solph.readthedocs.io/en/latest/usage.html#using-the-investment-mode>`_
+  *nonconvex* investment is applied (see `oemof-solph documentation <https://oemof-solph.readthedocs.io/en/latest/usage.html#investment-optimisation>`_
   for further information).
 * **capex_pipes**: Variable investment costs depending on the installed heat transport capacity
   (e.g. [€/kW]).

--- a/docs/whatsnew/v0-0-3.rst
+++ b/docs/whatsnew/v0-0-3.rst
@@ -13,6 +13,11 @@ New features
 
 * Pre-calculation function for optimisation parameters
 
+Geometry processing:
+
+* New method for connecting buildings to polygons boundary
+* Allow to keep index of buildings/consumer
+
 New components/constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/optimisation/import_osm_invest/import_osm_invest.py
+++ b/examples/optimisation/import_osm_invest/import_osm_invest.py
@@ -116,7 +116,8 @@ plt.show()
 tn_input = process_geometry(
     lines=gdf_lines_streets,
     producers=gdf_poly_gen,
-    consumers=gdf_poly_houses
+    consumers=gdf_poly_houses,
+    method="boundary",  # select the method of how to connect the buildings
 )
 
 # plot output after processing the geometry


### PR DESCRIPTION
This PR is mainly for implementing a new feature: Add a new method 'boundary' for creating the building connection point at the boundary/wall of the building, instead of the centroid. This results in much more realistic grid lengths.

Besides this new feature, this PR deals with a couple of issues that are closely related within the code. Creating separate PRs for the individual issues seemed too much of a hassle. Each subsequent commit works on its own, though.

- e571d35b108cf321dbe8392eb8a7458a064fa5e0, b25921f0536f9612b3e4f5f0817d785fd9c4fd99 and badf58030858c69363d4744ab046d8a2ef4855ed close #107
- 4b5560acef360818ba87eba2d749291b4c6a7dfa closes #108 
- c1870cb7894def12b901483b943a02b1ea108b5d closes #109

I have not updated any documentation. But since the only(?) documentation of [process_geometry()](https://dhnx.readthedocs.io/en/latest/api.html#dhnx.gistools.connect_points.process_geometry). seems to be the comment on the function itself, that at least is covered by my PR.