### PR TITLE
Replace print in precalc by logging

### DIFF
--- a/dhnx/optimization/precalc_hydraulic.py
+++ b/dhnx/optimization/precalc_hydraulic.py
@@ -34,6 +34,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)  # Create a logger for this module
 
+
 def eq_smooth(x, R_e):
     r"""
     Calculation of the pressure drop of hydraulic smooth surfaces.

--- a/dhnx/optimization/precalc_hydraulic.py
+++ b/dhnx/optimization/precalc_hydraulic.py
@@ -490,7 +490,7 @@ def v_max_secant(d_i, T_average, k=0.1, p_max=100, p_epsilon=1,
             v_0 = v_1
             v_1 = v_new
 
-    logging.info(
+    logger.info(
         "Maximum flow velocity calculated. Iterations: %d, "
         "Flow velocity: %.4f [m/s], Pressure drop: %.4f [Pa/m]"
         % (n, v_new, p_new)
@@ -579,11 +579,11 @@ def v_max_bisection(d_i, T_average, k=0.1, p_max=100,
                         pressure=pressure, fluid=fluid)
 
         if abs(p_new - p_max) < p_epsilon:
-            logging.info("Bi-section method: p_epsilon criterion reached.")
+            logger.info("Bi-section method: p_epsilon criterion reached.")
             break
 
         if abs(v_1 - v_0) < v_epsilon:  # wieso v_1 und v_0?
-            logging.info("Bi-section method: v_epsilon criterion reached.")
+            logger.info("Bi-section method: v_epsilon criterion reached.")
             break
 
         else:
@@ -594,7 +594,7 @@ def v_max_bisection(d_i, T_average, k=0.1, p_max=100,
             else:
                 v_0 = v_new
 
-    logging.info(
+    logger.info(
         "Maximum flow velocity calculated. Iterations: %d, "
         "Flow velocity: %.4f [m/s], Pressure drop: %.4f [Pa/m]"
         % (n, v_new, p_new)

--- a/dhnx/optimization/precalc_hydraulic.py
+++ b/dhnx/optimization/precalc_hydraulic.py
@@ -32,6 +32,7 @@ except ImportError:
     print("Need to install CoolProp to use the hydraulic "
           "pre-calculation module.")
 
+logger = logging.getLogger(__name__)  # Create a logger for this module
 
 def eq_smooth(x, R_e):
     r"""

--- a/dhnx/optimization/precalc_hydraulic.py
+++ b/dhnx/optimization/precalc_hydraulic.py
@@ -19,6 +19,7 @@ available from its original location:
 SPDX-License-Identifier: MIT
 """
 
+import logging
 import math
 
 import numpy as np
@@ -488,9 +489,11 @@ def v_max_secant(d_i, T_average, k=0.1, p_max=100, p_epsilon=1,
             v_0 = v_1
             v_1 = v_new
 
-    print('Number of Iterations: ', n)
-    print('Resulting pressure drop ', p_new)
-    print('Resulting velocity: ', v_new)
+    logging.info(
+        "Maximum flow velocity calculated. Iterations: %d, "
+        "Flow velocity: %f [m/s], Pressure drop: %f [Pa/m]"
+        % (n, v_new, p_new)
+    )
 
     return v_new
 
@@ -575,11 +578,11 @@ def v_max_bisection(d_i, T_average, k=0.1, p_max=100,
                         pressure=pressure, fluid=fluid)
 
         if abs(p_new - p_max) < p_epsilon:
-            print('p_epsilon criterion achieved!')
+            logging.info("Bi-section method: p_epsilon criterion reached.")
             break
 
         if abs(v_1 - v_0) < v_epsilon:  # wieso v_1 und v_0?
-            print('v_epsilon criterion achieved!')
+            logging.info("Bi-section method: v_epsilon criterion reached.")
             break
 
         else:
@@ -590,9 +593,11 @@ def v_max_bisection(d_i, T_average, k=0.1, p_max=100,
             else:
                 v_0 = v_new
 
-    print('Number of Iterations: ', n)
-    print('Resulting pressure drop: ', p_new)
-    print('Resulting velocity: ', v_new)
+    logging.info(
+        "Maximum flow velocity calculated. Iterations: %d, "
+        "Flow velocity: %f [m/s], Pressure drop: %f [Pa/m]"
+        % (n, v_new, p_new)
+    )
 
     return v_new
 

--- a/dhnx/optimization/precalc_hydraulic.py
+++ b/dhnx/optimization/precalc_hydraulic.py
@@ -491,7 +491,7 @@ def v_max_secant(d_i, T_average, k=0.1, p_max=100, p_epsilon=1,
 
     logging.info(
         "Maximum flow velocity calculated. Iterations: %d, "
-        "Flow velocity: %f [m/s], Pressure drop: %f [Pa/m]"
+        "Flow velocity: %.4f [m/s], Pressure drop: %.4f [Pa/m]"
         % (n, v_new, p_new)
     )
 
@@ -595,7 +595,7 @@ def v_max_bisection(d_i, T_average, k=0.1, p_max=100,
 
     logging.info(
         "Maximum flow velocity calculated. Iterations: %d, "
-        "Flow velocity: %f [m/s], Pressure drop: %f [Pa/m]"
+        "Flow velocity: %.4f [m/s], Pressure drop: %.4f [Pa/m]"
         % (n, v_new, p_new)
     )
 


### PR DESCRIPTION
There are print statements in the hydraulic pre calculation. This PR replaces them by logging.info.
