### PR TITLE
Fix various errors in network connections

### DIFF
--- a/dhnx/gistools/connect_points.py
+++ b/dhnx/gistools/connect_points.py
@@ -550,6 +550,8 @@ def process_geometry(lines, consumers, producers,
         lines, lines_producers, lines_consumers,
         # debug_plotting=True,
     )
+    # Keep only the shortest of all lines connecting the same two points
+    lines = go.drop_parallel_lines(lines)
 
     # add additional line identifier
     lines_producers['type'] = 'GL'  # GL for generation line

--- a/dhnx/gistools/connect_points.py
+++ b/dhnx/gistools/connect_points.py
@@ -339,7 +339,9 @@ def run_point_method_boundary(
     the 'midpoint' method.
 
     In case of no intersections with the building boundary (possible for e.g.
-    U-shaped buildings), the original centroid is used.
+    U-shaped buildings), the original centroid is used. This is also
+    necessary when the the street line already touches the building, to
+    prevent deleting the connection line.
 
     Parameters
     ----------
@@ -401,7 +403,7 @@ def run_point_method_boundary(
 
     # Repeat for the producers
     producers_n = gpd.GeoDataFrame(geometry=lines_producers.intersection(
-        producers_poly.convex_hull.boundary, align=False))
+        producers_poly.boundary, align=False))
     producers_n.loc[producers_n.type == "MultiPoint"] = \
         gpd.GeoDataFrame(geometry=lines_producers.intersection(
             producers_poly.convex_hull.boundary, align=False))
@@ -412,11 +414,25 @@ def run_point_method_boundary(
     # Sometimes the new lines are empty (e.g. because a street and a building
     # object cross each other).
     # In these cases the original geometry is used for points and lines.
-    mask = (consumers_n.is_empty | lines_consumers_n.is_empty)
+    mask1 = (consumers_n.is_empty | lines_consumers_n.is_empty)
+
+    # Another special case has to be covered. If the original street lines
+    # already touch the building wall, no additional connection line would be
+    # necessary. However, in dhnx each building needs one connection line.
+    # Thus the geometry from the 'midpoint' method is used here, too.
+    # Find the problematic cases by testing if the new connection point
+    # equals the starting point of the connection line.
+    mask2 = consumers_n.geom_equals(
+        lines_consumers.geometry.apply(lambda line: line.boundary.geoms[0]))
+    mask = mask1 | mask2
     consumers_n.loc[mask] = consumers.loc[mask].geometry
     lines_consumers_n.loc[mask] = lines_consumers.loc[mask].geometry
 
-    mask = (producers_n.is_empty | lines_producers_n.is_empty)
+    # Repeat for the producers
+    mask1 = (producers_n.is_empty | lines_producers_n.is_empty)
+    mask2 = producers_n.geom_equals(
+        lines_producers.geometry.apply(lambda line: line.boundary.geoms[0]))
+    mask = mask1 | mask2
     producers_n.loc[mask] = producers.loc[mask].geometry
     lines_producers_n.loc[mask] = lines_producers.loc[mask].geometry
 

--- a/dhnx/gistools/geometry_operations.py
+++ b/dhnx/gistools/geometry_operations.py
@@ -493,7 +493,7 @@ def drop_parallel_lines(gdf):
     """
     # Stores each LineString's endpoints and length in temporary columns
     gdf['5d7u6j_endpoints'] = gdf.geometry.apply(
-            lambda line: tuple(sorted([line.coords[0], line.coords[-1]])))
+        lambda line: tuple(sorted([line.coords[0], line.coords[-1]])))
     gdf['5d7u6j_length'] = gdf.geometry.length
 
     # Group by endpoints and keep only the shortest LineString for each group

--- a/dhnx/gistools/geometry_operations.py
+++ b/dhnx/gistools/geometry_operations.py
@@ -159,7 +159,8 @@ def check_double_points(gdf, radius=0.001, id_column=None):
 
         point = c['geometry']
         gdf_other = gdf.drop([r])
-        other_points = unary_union(gdf_other['geometry'])
+        # Prevent OSError, see https://github.com/oemof/DHNx/issues/107
+        other_points = unary_union(list(gdf_other['geometry']))
 
         # x1 = nearest_points(point, other_points)[0]
         x2 = nearest_points(point, other_points)[1]


### PR DESCRIPTION
This PR attempts to resolve #127 and the various problems described in it.
No function interfaces are changed and I think this could be considered a "hotfix" to v0.0.3.

### Improve 'weld_segments' function
- Replace some for-loops with vectorized functions for better performance. The recursive design is still quite slow, but the change showed a 4x speed improvement in one test case.
- Fix an error that could remove lines unintentionally

### Add plot for investigation of node-mismatch errors
- This helps identify where the error is located, e.g. when a network consists of unconnected components

### Update 'boundary' line connection method
- Catch special cases where the regular street lines already touch the building. This would already fulfill the boundary method, but for dhnx a connection line is required for each building. Use midpoint for these cases.
- Remove a misplaced 'convex_hull' call

### Implement a new function 'drop_parallel_lines'
- If multiple lines connect the same two points in a network, eomof.solph will throw an error. Keep only the shortest of all lines connecting the same two points.
- Since this is called only after all building connections have been created, I think it is save to remove those duplicate lines. There should be no circumstances where the solver chooses a longer line over a shorter one.

### Prevent OSError exception in unary_union()
- This issue was already discussed in #107 and fixed for connect_points.py in b25921f. Now the same access violation error came up at this point. It could be confirmed that the issue happens only with shapely < 2.0 and is not occuring with shapely >= 2.0.
- If that ever becomes a requirement, the 'list()' could be removed.