### PR TITLE
Fix and update HeatPipeine classes / oemof_heatpipe.py

### DIFF
--- a/dhnx/optimization/oemof_heatpipe.py
+++ b/dhnx/optimization/oemof_heatpipe.py
@@ -269,8 +269,14 @@ class HeatPipelineBlock(ScalarBlock):  # pylint: disable=too-many-ancestors
             o = list(n.outputs.keys())[0]
 
             expr = 0
-            expr += - m.flow[n, o, t]
-            expr += m.flow[i, n, t]
+            try:  # oemof.solph<=0.5.0
+                expr += - m.flow[n, o, t]
+                expr += m.flow[i, n, t]
+            except KeyError:  # oemof.solph>=0.5.1
+                period = 0  # Periods are not (yet) supported in DHNx
+                expr += - m.flow[n, o, period, t]
+                expr += m.flow[i, n, period, t]
+
             expr += - block.heat_loss[n, t]
             return expr == 0
 

--- a/dhnx/optimization/oemof_heatpipe.py
+++ b/dhnx/optimization/oemof_heatpipe.py
@@ -66,12 +66,23 @@ class HeatPipeline(Transformer):
 
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        inputs,
+        outputs,
+        label=None,
+        heat_loss_factor=0,
+        heat_loss_factor_fix=0,
+    ):
 
-        self.heat_loss_factor = sequence(kwargs.get('heat_loss_factor', 0))
-        self.heat_loss_factor_fix = sequence(kwargs.get(
-            'heat_loss_factor_fix', 0))
+        self.heat_loss_factor = sequence(heat_loss_factor)
+        self.heat_loss_factor_fix = sequence(heat_loss_factor_fix)
+
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            label=label,
+        )
 
         self._invest_group = False
         self._nonconvex_group = False

--- a/dhnx/optimization/oemof_heatpipe.py
+++ b/dhnx/optimization/oemof_heatpipe.py
@@ -34,10 +34,10 @@ class Label(namedtuple('solph_label', ['tag1', 'tag2', 'tag3', 'tag4'])):
 
 class HeatPipeline(Transformer):
     r"""A HeatPipeline represent a Pipeline in a district heating system.
+
     This is done by a Transformer with a constant energy loss independent of
-    actual power, but dependent on the nominal power and the length parameter.
-    The HeatPipeline is a single-input-single-output transformer. Additionally,
-    conversion factors for in- and output flow can be applied.
+    actual power, but dependent on the nominal power.
+    The HeatPipeline is a single-input-single-output transformer.
 
     Parameters
     ----------
@@ -189,10 +189,6 @@ class HeatPipelineBlock(ScalarBlock):  # pylint: disable=too-many-ancestors
         loss of heat pipeline"
         ":math:`\dot{Q}_{nominal}`", ":py:obj:`flows[n, o].nominal_value`", "
         P", "Nominal capacity of heating pipeline"
-        ":math:`\eta_{out}`", ":py:obj:`conversion_factors[o][t]`", "P", "
-        Conversion factor of output flow (Heat Output)"
-        ":math:`\eta_{in}`", ":py:obj:`conversion_factors[i][t]`", "P", "
-        Conversion factor of input flow (Heat Input)"
         ":math:`f_{loss}(t)`", ":py:obj:`heat_loss_factor`", "P", "Specific
         heat loss factor for pipeline"
         ":math:`l`", ":py:obj:`length`", "P", "Length of heating pipeline"
@@ -311,10 +307,6 @@ class HeatPipelineInvestBlock(ScalarBlock):  # pylint: disable=too-many-ancestor
         loss of heat pipeline"
         ":math:`\dot{Q}_{nominal}`", ":py:obj:`flows[n, o].nominal_value`", "
         V", "Nominal capacity of heating pipeline"
-        ":math:`\eta_{out}`", ":py:obj:`conversion_factors[o][t]`", "P", "
-        Conversion factor of output flow (heat output)"
-        ":math:`\eta_{in}`", ":py:obj:`conversion_factors[i][t]`", "P", "
-        Conversion factor of input flow (heat input)"
         ":math:`f_{loss}(t)`", ":py:obj:`heat_loss_factor`", "P", "Specific
         heat loss factor for pipeline"
         ":math:`l`", ":py:obj:`length`", "P", "Length of heating pipeline"
@@ -444,15 +436,13 @@ class HeatPipelineInvestBlock(ScalarBlock):  # pylint: disable=too-many-ancestor
             expr = 0
             try:  # oemof.solph<=0.5.0
                 expr += - m.flow[n, o, t]
-                expr += m.flow[i, n, t] * n.conversion_factors[
-                    o][t] / n.conversion_factors[i][t]
+                expr += m.flow[i, n, t]
                 expr += - block.heat_loss[n, t]
                 expr += - m.flow[n, d, t]
             except KeyError:  # oemof.solph>=0.5.1
                 period = 0  # Periods are not (yet) supported in DHNx
                 expr += - m.flow[n, o, period, t]
-                expr += m.flow[i, n, period, t] * n.conversion_factors[
-                    o][t] / n.conversion_factors[i][t]
+                expr += m.flow[i, n, period, t]
                 expr += - block.heat_loss[n, t]
                 expr += - m.flow[n, d, period, t]
 


### PR DESCRIPTION
The following issues are addressed. Sorry for putting it all in this PR. This is a complete revision of `dhnx/optimization/oemof_heatpipe.py`

* [x] Fix oemof network 0.5.0:
There were changes in oemof.network with the release 0.5.0, e.g. making function signatures explicit, that lead errors with the specific attributes of the HeatPipeline class, as the Heatpipeline class inherit from oemof.network Transformer.
An update of the initiation function solves the problem, and making the arguments explicit also makes things clearer.

* [x] Remove conversion factors:
  These were only partly implemented and do not make sense in the component. If these are needed in some cases, we could properly add them again.

* [ ] Fix docstrings:
  The docstrings are not up to date.

* [x] Fix solph 0.5.1 (periods) for existing heatpipelines