### PR TITLE
Fix description of pressure unit from 'bar' to 'Pa'

### DIFF
--- a/dhnx/optimization/precalc_hydraulic.py
+++ b/dhnx/optimization/precalc_hydraulic.py
@@ -354,7 +354,7 @@ def delta_p(v, d_i, k=0.1, T_medium=90, length=1,
 
     Returns
     -------
-    Pressure drop [bar] : numeric
+    Pressure drop [Pa] : numeric
 
     """
     k = k * 0.001


### PR DESCRIPTION
Fix a very minor issue with an incorrect unit in the docstring of the function ```delta_p()``` in ```precalc_hydraulic.py```.

Fixes #143

