### PR TITLE
Feature: Allow multiple potential building connections

### DIFF
--- a/dhnx/gistools/connect_points.py
+++ b/dhnx/gistools/connect_points.py
@@ -217,7 +217,7 @@ def create_object_connections(points, lines, tol_distance=1, n_conn=1,
                 tol_distance=tol_distance)
 
             lines_drop.extend(nearest_line_idx)
-            if drop_neighbours and i+1 < n_conn:
+            if drop_neighbours and i + 1 < n_conn:
                 # Find all neighbours of the nearest segment(s) and delete them
                 # as well. Chances are that they do not provide an advantage
                 # over the nearest segment. This allows the next connection
@@ -233,7 +233,7 @@ def create_object_connections(points, lines, tol_distance=1, n_conn=1,
 
         # Create a GeoDataFrame with the connection lines of the current id
         gdf_conn_lines_id = gpd.GeoDataFrame(
-            data={'id_full': [id_full]*len(conn_lines_id)},
+            data={'id_full': [id_full] * len(conn_lines_id)},
             geometry=conn_lines_id, crs=lines.crs)
 
         # Drop duplicate geometries in connection lines
@@ -259,16 +259,13 @@ def create_object_connections(points, lines, tol_distance=1, n_conn=1,
                 # Remove the line that is to be replaced
                 lines.drop([nearest_line_idx], inplace=True)
                 # Combine remaining lines with two new replacement lines
-                lines = pd.concat(
-                    [gpd.GeoDataFrame(lines, crs=lines.crs),
-                     gpd.GeoDataFrame(
-                         geometry=[
-                             LineString([line_start, conn_point]),
-                             LineString([conn_point, line_end])],
-                         crs=lines.crs,
-                         data=pd.concat([attributes, attributes]),  # keep data
-                         ),
-                     ],
+                lines = pd.concat([
+                    gpd.GeoDataFrame(lines, crs=lines.crs),
+                    gpd.GeoDataFrame(
+                        geometry=[LineString([line_start, conn_point]),
+                                  LineString([conn_point, line_end])],
+                        crs=lines.crs,
+                        data=pd.concat([attributes, attributes]))],
                     ignore_index=True)
 
         conn_lines_list.append(gdf_conn_lines_id)

--- a/dhnx/optimization/optimization_models.py
+++ b/dhnx/optimization/optimization_models.py
@@ -446,10 +446,10 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                 try:
                     # that's in case of a one timestep optimisation due to
                     # an oemof bug in outputlib
-                    invest = res[outflow[0]]['sequences']['invest'][0]
+                    invest = res[outflow[0]]['sequences']['invest'].iloc[0]
                 except (KeyError, IndexError):
-                    # this is in case there is no bi-directional heatpipe, e.g. at
-                    # forks-consumers, producers-forks
+                    # this is in case there is no bi-directional heatpipe,
+                    # e.g. at forks-consumers, producers-forks
                     invest = 0
 
             # the rounding is performed due to numerical issues
@@ -469,10 +469,10 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                 try:
                     # that's in case of a one timestep optimisation due to
                     # an oemof bug in outputlib
-                    invest_status = res[outflow[0]]['sequences']['invest_status'][0]
+                    invest_status = res[outflow[0]]['sequences']['invest_status'].iloc[0]
                 except (KeyError, IndexError):
-                    # this is in case there is no bi-directional heatpipe, e.g. at
-                    # forks-consumers, producers-forks
+                    # this is in case there is no bi-directional heatpipe,
+                    # e.g. at forks-consumers, producers-forks
                     invest_status = 0
 
             return invest_status
@@ -667,7 +667,7 @@ def optimize_operation(thermal_network):
 
 def setup_optimise_investment(
         thermal_network, invest_options, heat_demand='scalar', num_ts=1,
-        time_res=1, start_date='1/1/2018', frequence='H', solver='cbc',
+        time_res=1, start_date='1/1/2018', frequence='h', solver='cbc',
         solve_kw=None, solver_cmdline_options=None, simultaneity=1,
         bidirectional_pipes=False, dump_path=None, dump_name='dump.oemof',
         print_logging_info=False, write_lp_file=False):

--- a/dhnx/optimization/optimization_models.py
+++ b/dhnx/optimization/optimization_models.py
@@ -438,7 +438,7 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                        if lab == str(x[0].label)]
 
             if len(outflow) > 1:
-                print('Multiple IDs!')
+                logger.info('Multiple IDs!')
 
             try:
                 invest = res[outflow[0]]['scalars']['invest']
@@ -513,7 +513,7 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                 for r, c in df.iterrows():
                     if df.at[r, hp_lab + '.' + 'status-1'] + \
                             df.at[r, hp_lab + '.' + 'status-2'] > 1:
-                        print(
+                        logger.warning(
                             "Investment status of pipe id {} is 1 for both dircetions!"
                             " This is not allowed!".format(r)
                         )
@@ -522,7 +522,7 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                             or\
                             (df.at[r, hp_lab + '.' + 'status-2'] == 1 and df.at[
                                 r, hp_lab + '.' + 'size-2'] == 0):
-                        print(
+                        logger.warning(
                             "Investment status of pipe id {} is 1, and capacity is 0!"
                             "What happend?!".format(r)
                         )
@@ -766,7 +766,7 @@ def solve_optimisation_investment(model):
     if model.settings['dump_path'] is not None:
         my_es = model.es
         my_es.dump(dpath=model.settings['dump_path'], filename=model.settings['dump_name'])
-        print('oemof Energysystem stored in "{}"'.format(model.settings['dump_path']))
+        logger.info('oemof Energysystem stored in "{}"'.format(model.settings['dump_path']))
 
     edges_results = model.get_results_edges()
 

--- a/dhnx/optimization/optimization_models.py
+++ b/dhnx/optimization/optimization_models.py
@@ -184,11 +184,10 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                         "The consumer {} of pipe id {} does not exist!"
                         .format(cons_id, p))
 
-        pipe_to_cons_ids = list(self.thermal_network.components['pipes']['to_node'].values)
-        pipe_to_cons_ids = [x.split('-', 1)[1] for x in pipe_to_cons_ids
-                            if x.split('-', 1)[0] == 'consumers']
-
-        for id in list(self.thermal_network.components['consumers'].index):
+        pipe_to_cons_ids = list(
+            self.thermal_network.components['pipes']['to_node'].values)
+        pipe_to_cons_ids = [x for x in pipe_to_cons_ids if 'consumers' in x]
+        for id in list(self.thermal_network.components['consumers']['id_full']):
             if id not in pipe_to_cons_ids:
                 raise ValueError(
                     "The consumer id {} has no connection the the grid!".format(id))


### PR DESCRIPTION
This PR merges some ongoing development of DHNx

## 7da0502 Allow multiple potential building connections

DHNx requires connecting each building to the line network, e.g. the streets. To do this, create_object_connections() normally
finds the perpendicular line which represents the closest connection between building and street.

This commit updates create_object_connections() to allow more than 1 (default value) number of connections 'n_conn' to be created. During the optimization phase, the solver now has multiple options to choose from when finding the best district heating network.

This may be desired when the nearest street segment is not actually the best way to connect a building. In cases where a building has a street or path in the front and back, both may be valid options.

For each line segment that a possible connection has been attached to, its direct connections are ignored when searching for the next possible line segment. This mostly avoids obviously inferior alternative connections and helps find more relevant alternatives.

To allow this functionality, create_object_connections() had to be completely rewritten. But the default settings should
retain the old behaviour.

This feature increases the optimization time.

Further updates required for supporting multiple connection lines:

insert_node_ids() in geometry_operations.py

check_input() in optimization_models.py

## 153cd11 Simplify and improve run_point_method_boundary()

Previously, run_point_method_boundary() required consumer and producer data as input and repeated all steps for both data
sets. To avoid unnecessary code repetition, the duplicates were removed and the function now has to be called once with
consumer data and once with producer data as input. 
Additionally, incorrect behaviour for some edge cases was fixed and support for the multiple connection lines implemented in 
create_object_connections() was added. 

Usage of the function weld_segments(), which welds continuous line segments together and cuts loose ends has been made optional via the parameter 'welding' (default is True)

The function process_geometry() had to be adapted to support the changes in create_object_connections() and run_point_method_boundary()


## d9a05a5 Enforce reduction of 3D geometry to 2D

Most underlying functions (e.g. distance measurement in shapely) do not support 3D geometries. Having z-coordinates in the
data can cause issues in several places in the code, especially when e.g. buildings contain z coordinates, but streets do not.

The savest option currently is to force 2d on all input geometries, which is now the default in check_crs()

## Other changes included in this PR
34d9664 Fix deprecations in pandas>=2.0
0932a07 Replace print statements with logger info and warning
