### PR TITLE
Partially revert 7da0502

### DIFF
--- a/dhnx/optimization/optimization_models.py
+++ b/dhnx/optimization/optimization_models.py
@@ -184,10 +184,11 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                         "The consumer {} of pipe id {} does not exist!"
                         .format(cons_id, p))
 
-        pipe_to_cons_ids = list(
-            self.thermal_network.components['pipes']['to_node'].values)
-        pipe_to_cons_ids = [x for x in pipe_to_cons_ids if 'consumers' in x]
-        for id in list(self.thermal_network.components['consumers']['id_full']):
+        pipe_to_cons_ids = list(self.thermal_network.components['pipes']['to_node'].values)
+        pipe_to_cons_ids = [x.split('-', 1)[1] for x in pipe_to_cons_ids
+                            if x.split('-', 1)[0] == 'consumers']
+
+        for id in list(self.thermal_network.components['consumers'].index):
             if id not in pipe_to_cons_ids:
                 raise ValueError(
                     "The consumer id {} has no connection the the grid!".format(id))


### PR DESCRIPTION
When developing the "multiple building connections" feature (#147) the check for successful consumer-to-grid connections in  optimization_models.py (seemingly) had to be adapted. However, using the ``id_full`` attribute broke some of the simple example scripts that never define this attribute. As it turns out, multiple building connections work just fine without this particular change in 7da0502, so it is hereby reverted to the previous state.

Fixes #149 