### PR TITLE
Follow API udaptes of solph

### DIFF
--- a/dhnx/optimization/add_components.py
+++ b/dhnx/optimization/add_components.py
@@ -204,9 +204,10 @@ def add_demand(it, labels, series, nodes, busd):
         labels['l_3'] = 'demand'
         labels['l_2'] = de['label_2']
         # set static inflow values
-        inflow_args = {'nominal_value': de['nominal_value'],
-                       'fix': series['heat_flow'][
-                           labels['l_4'].split('-', 1)[1]].values}
+        inflow_args = {
+            "nominal_capacity": de["nominal_capacity"],
+            "fix": series["heat_flow"][labels["l_4"].split("-", 1)[1]].values,
+        }
 
         # create
         nodes.append(
@@ -268,7 +269,7 @@ def add_transformer(it, labels, nodes, busd):
                         outputs={b_out_1: solph.Flow(
                             variable_costs=t['variable_costs'],
                             summed_max=t['in_1_sum_max'],
-                            investment=solph.Investment(
+                            nominal_capacity=solph.Investment(
                                 ep_costs=epc_t + t['service'],
                                 maximum=t['max_invest'],
                                 minimum=t['min_invest']))},
@@ -290,7 +291,7 @@ def add_transformer(it, labels, nodes, busd):
                                        labels['l_4']),
                         inputs={b_in_1: solph.Flow()},
                         outputs={b_out_1: solph.Flow(
-                            nominal_value=t['installed'],
+                            nominal_capacity=t['installed'],
                             summed_max=t['in_1_sum_max'],
                             variable_costs=t['variable_costs'])},
                         conversion_factors={b_out_1: t['eff_out_1']}))
@@ -346,7 +347,7 @@ def add_storage(it, labels, nodes, busd):
                     inflow_conversion_factor=s['inflow_conversion_factor'],
                     outflow_conversion_factor=s[
                         'outflow_conversion_factor'],
-                    investment=solph.Investment(ep_costs=epc_s)))
+                    nominal_capacity=solph.Investment(ep_costs=epc_s)))
 
         else:
             nodes.append(
@@ -411,13 +412,12 @@ def add_heatpipes(it, labels, bidirectional, length, b_in, b_out, nodes):
             label=oh.Label(labels['l_1'], labels['l_2'],
                            labels['l_3'], labels['l_4']),
             inputs={b_in: solph.Flow(
-                investment=solph.Investment(),
+                nominal_capacity=solph.Investment(),
                 **flow_bi_args,
             )},
             outputs={b_out: solph.Flow(
-                nominal_value=None,
                 **flow_bi_args,
-                investment=solph.Investment(
+                nominal_capacity=solph.Investment(
                     ep_costs=epc_p, maximum=t['cap_max'],
                     minimum=t['cap_min'], nonconvex=nc, offset=epc_fix,
                 ))},
@@ -473,11 +473,11 @@ def add_heatpipes_exist(pipes, labels, gd, q, b_in, b_out, nodes):
         label=oh.Label(labels['l_1'], labels['l_2'],
                        labels['l_3'], labels['l_4']),
         inputs={b_in: solph.Flow(
-            nominal_value=q['capacity'],
+            nominal_capacity=q['capacity'],
             **flow_bi_args,
         )},
         outputs={b_out: solph.Flow(
-            nominal_value=q['capacity'],
+            nominal_capacity=q['capacity'],
             **flow_bi_args,
             **outflow_args,
         )},

--- a/dhnx/optimization/oemof_heatpipe.py
+++ b/dhnx/optimization/oemof_heatpipe.py
@@ -14,7 +14,7 @@ SPDX-License-Identifier: MIT
 import warnings
 from collections import namedtuple
 
-from oemof.network import Transformer
+from oemof.network import Node
 from oemof.solph import Investment
 from oemof.solph._plumbing import sequence
 from pyomo.core.base.block import ScalarBlock
@@ -32,7 +32,7 @@ class Label(namedtuple('solph_label', ['tag1', 'tag2', 'tag3', 'tag4'])):
         return '_'.join(map(str, self._asdict().values()))
 
 
-class HeatPipeline(Transformer):
+class HeatPipeline(Node):
     r"""A HeatPipeline represent a Pipeline in a district heating system.
 
     This is done by a Transformer with a constant energy loss independent of

--- a/dhnx/optimization/optimization_models.py
+++ b/dhnx/optimization/optimization_models.py
@@ -67,7 +67,7 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
         Attribute, which will be the oemof.solph.Model for optimisation.
     oemof_flow_attr : set
         Possible flow attributes, which can be used additionally:
-        {'nominal_value', 'min', 'max', 'variable_costs', 'fix'}
+        {'nominal_capacity', 'min', 'max', 'variable_costs', 'fix'}
     results : dict
         Empty dictionary for the results.
 
@@ -95,7 +95,7 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
         self.om = None
 
         # list of possible oemof flow attributes, e.g. for producers source
-        self.oemof_flow_attr = {'nominal_value', 'min', 'max',
+        self.oemof_flow_attr = {'nominal_capacity', 'min', 'max',
                                 'variable_costs', 'fix'}
 
         super().__init__(thermal_network)

--- a/docs/_static/opti_consumer_demand.csv
+++ b/docs/_static/opti_consumer_demand.csv
@@ -1,2 +1,2 @@
-label_2,active,nominal_value
+label_2,active,nominal_capacity
 heat,1,1

--- a/docs/optimization_models.rst
+++ b/docs/optimization_models.rst
@@ -295,7 +295,7 @@ everybody is free to choose his own units (energy, mass flow, etc.).
   Recommended to use with `nonconvex` is `True`.
 * **cap_max**: Maximum installable capacity (e.g. [kW]).
 * **cap_min**: Minimum installable capacity (e.g. [kW]). Note that there is a difference if a
-  *nonconvex* investment is applied (see `oemof-solph documentation <https://oemof-solph.readthedocs.io/en/latest/usage.html#investment-optimisation>`_
+  *nonconvex* investment is applied (see `oemof-solph documentation <https://oemof-solph.readthedocs.io/en/stable/optimization/dispatch_vs_invest.html>`_
   for further information).
 * **capex_pipes**: Variable investment costs depending on the installed heat transport capacity
   (e.g. [€/kW]).
@@ -450,11 +450,6 @@ You can also check out the detailed results of the oemof model, which are stored
 
     # oemof-solph results "meta"
     r_oemof_meta = network.results.optimization['oemof_meta']
-
-Or you can also dump the oemof results and analyze the results as described in
-`oemof-solph handling results <https://oemof-solph.readthedocs.io/en/latest/usage.html#handling-results>`_.
-The labelling systematic will help you to easily get want you want,
-check :ref:`Label system <Label system>`.
 
 
 Introducing example

--- a/examples/optimisation/discrete_DN_numbers/invest_data/consumers/demand.csv
+++ b/examples/optimisation/discrete_DN_numbers/invest_data/consumers/demand.csv
@@ -1,2 +1,2 @@
-label_2,active,nominal_value
+label_2,active,nominal_capacity
 heat,1,1

--- a/examples/optimisation/import_osm_invest/import_osm_invest.py
+++ b/examples/optimisation/import_osm_invest/import_osm_invest.py
@@ -20,6 +20,7 @@ import numpy as np
 import osmnx as ox
 from shapely import geometry
 import matplotlib.pyplot as plt
+import os
 
 import logging
 from oemof.tools import logger
@@ -32,6 +33,8 @@ logger.define_logging(
     screen_level=logging.INFO,
     logfile="dhnx.log"
 )
+
+os.chdir(os.path.dirname(__file__))
 
 # Part I: Get OSM data #############
 
@@ -144,7 +147,7 @@ for k, v in tn_input.items():
 network.is_consistent()
 
 # load the specification of the oemof-solph components
-invest_opt = load_invest_options('invest_data')
+invest_opt = load_invest_options('./invest_data')
 
 
 # optionally, define some settings for the solver. Especially increasing the

--- a/examples/optimisation/import_osm_invest/invest_data/consumers/demand.csv
+++ b/examples/optimisation/import_osm_invest/invest_data/consumers/demand.csv
@@ -1,2 +1,2 @@
-label_2,active,nominal_value
+label_2,active,nominal_capacity
 heat,1,1

--- a/examples/optimisation/introduction/invest_data/consumers/demand.csv
+++ b/examples/optimisation/introduction/invest_data/consumers/demand.csv
@@ -1,2 +1,2 @@
-label_2,active,nominal_value
+label_2,active,nominal_capacity
 heat,1,1

--- a/examples/optimisation/invest_with_existing/invest_data/consumers/demand.csv
+++ b/examples/optimisation/invest_with_existing/invest_data/consumers/demand.csv
@@ -1,2 +1,2 @@
-,label_2,active,nominal_value
+,label_2,active,nominal_capacity
 0,heat,1,1

--- a/examples/optimisation/minimal_network/invest_data/consumers/demand.csv
+++ b/examples/optimisation/minimal_network/invest_data/consumers/demand.csv
@@ -1,2 +1,2 @@
-label_2,active,nominal_value
+label_2,active,nominal_capacity
 heat,1,1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'pillow',
         'folium',
         'addict',
-        'oemof.solph >= 0.5, < 0.6',
+        'oemof.solph >= 0.6',
         'scipy >= 1.5',
     ],
     extras_require={

--- a/tests/_files/investment/invest_options/consumers/demand.csv
+++ b/tests/_files/investment/invest_options/consumers/demand.csv
@@ -1,2 +1,2 @@
-,label_2,active,nominal_value
+,label_2,active,nominal_capacity
 0,heat,1,1


### PR DESCRIPTION
This is to update to changed APIs of solph. DHNX does not work with solph v0.6 as we updated to solph 0.5 only using its compatibility wrappers. This, I suggest to do a hard update here and drop support for solph v0.5.