### PR TITLE
Improve robustness of welding

### DIFF
--- a/src/dhnx/gistools/geometry_operations.py
+++ b/src/dhnx/gistools/geometry_operations.py
@@ -229,11 +229,11 @@ def check_double_points(gdf, radius=0.001, id_column=None):
     return l_ids
 
 
-def gdf_to_df(gdf):
+def gdf_to_df(df):
     """Converts a GeoDataFrame to a pandas.DataFrame by deleting the geometry
     column."""
-
-    df = pd.DataFrame(gdf[[col for col in gdf.columns if col != "geometry"]])
+    if isinstance(df, gpd.GeoDataFrame):
+        df = df.drop(columns=df.geometry.name)
 
     return df
 

--- a/src/dhnx/gistools/geometry_operations.py
+++ b/src/dhnx/gistools/geometry_operations.py
@@ -364,6 +364,9 @@ def weld_segments(
         gdf_line_net_new = _weld_segments(
             gdf_line_net_new, gdf_line_gen, gdf_line_houses, debug_plotting
         )
+        if len(gdf_line_net_new) == 0:
+            gdf_line_net_new = gdf_line_net_last
+            break
     logger.info("Welding lines... done")
     return gdf_line_net_new
 
@@ -586,6 +589,7 @@ def _weld_segments(
         # Merge the MultiLineString into a single object
         merged_line = linemerge(multi_line)
         gdf_merged = gpd.GeoDataFrame(geometry=[merged_line], crs=crs)
+        gdf_merged = gdf_merged.explode()  # Explode Multi- into LineStrings
         debug_plot(neighbours)  # Plot the segments before the merge
         debug_plot(gdf_merged, color="orange")  # ...and after the merge
         gdf_line_net_new = pd.concat(


### PR DESCRIPTION
I have noticed PR #157 and I approve any attempts to make the welding faster. I did not have a chance to look at that approach yet.

In the meantime, the changes here were waiting to be pushed. They catch some rare edge cases where the welding did not behave as expected. Maybe this is not required if PR #157 gets merged instead.

For good measure, another tiny fix is included in this PR, where ``gdf_to_df()`` depended on ``gdf.geometry.name == "geometry"``, which is not always true. The fix should be much saver.