### PR TITLE
Fix errors in building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,8 @@ linkcheck_ignore = [r"https://requires.io/.*"] + (
     [
         r"https://github.com/oemof/DHNx/issues/*",
         r"https://github.com/oemof/DHNx/pulls/*",
+        # 'Unsupported Media Type' despite valid link in 2026
+        r"https://www.schweizer-fn.de/stroemung/rauhigkeit/rauhigkeit.php",
     ]
     if "TRAVIS" not in os.environ
     else []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.imgmath",
+    "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
 ]
 source_suffix = ".rst"

--- a/docs/network.rst
+++ b/docs/network.rst
@@ -11,7 +11,7 @@ rendered in the following table.
 
 .. csv-table::
    :header-rows: 1
-   :file: ../dhnx/components.csv
+   :file: ../src/dhnx/components.csv
 
 Every component has a number of attributes which are defined in
 `components_attrs/ <https://github.com/oemof/DHNx/blob/dev/src/dhnx/component_attrs>`_.
@@ -29,7 +29,7 @@ They are characterized by these attributes:
 
 .. csv-table::
    :header-rows: 1
-   :file: ../dhnx/component_attrs/consumers.csv
+   :file: ../src/dhnx/component_attrs/consumers.csv
 
 
 Producer
@@ -40,7 +40,7 @@ Producers are described with the following attributes:
 
 .. csv-table::
    :header-rows: 1
-   :file: ../dhnx/component_attrs/producers.csv
+   :file: ../src/dhnx/component_attrs/producers.csv
 
 
 Fork
@@ -51,7 +51,7 @@ Forks have the attributes described in the following table:
 
 .. csv-table::
    :header-rows: 1
-   :file: ../dhnx/component_attrs/forks.csv
+   :file: ../src/dhnx/component_attrs/forks.csv
 
 
 Pipe
@@ -62,4 +62,4 @@ They are characterized by these attributes:
 
 .. csv-table::
    :header-rows: 1
-   :file: ../dhnx/component_attrs/pipes.csv
+   :file: ../src/dhnx/component_attrs/pipes.csv

--- a/docs/optimization_models.rst
+++ b/docs/optimization_models.rst
@@ -23,7 +23,7 @@ Scope
 The following questions can be addressed using the `optimize_investment` method
 of the *ThermalNetwork*:
 
-* What is the cost-optimal topology and dimensioning of a DHS piping system, 
+* What is the cost-optimal topology and dimensioning of a DHS piping system,
   given the locations of potential central heat supply plants, the potential
   locations for the DHS piping system (e.g. street network),
   and the position of consumers?
@@ -65,7 +65,7 @@ The optimisation of a given *ThermalNetwork* is executed by:
     import dhnx
 
     tnw = dhnx.network.ThermalNetwork()
-    
+
     tnw = network.from_csv_folder('path/to/thermal_network')
 
     invest_opt = dhnx.input_output.load_invest_options('path/to/invest_options')
@@ -246,7 +246,7 @@ the `optimize_investment()` method of the *ThermalNetwork*, you need to provide
 some additional data providing the investment parameter.
 The following sheme illustrates the structure of the investment input data:
 
-.. include:: ../dhnx/input_output.py
+.. include:: ../src/dhnx/input_output.py
   :start-after: .. _folder_structure_invest:
   :end-before: Parameters
 
@@ -323,7 +323,7 @@ The minimum requirement for doing an DHS optimisation is to provide an demand at
 Therefore, you need the following two .csv files: *bus.csv* specifies the
 *oemof-solph* *Bus* components, and *demand.csv* defines the *oemof.solph.Sink*.
 
-.. include:: ../dhnx/optimization/add_components.py
+.. include:: ../src/dhnx/optimization/add_components.py
   :start-after: .. _bus_table:
   :end-before: Parameters
 
@@ -350,7 +350,7 @@ DHS system. That means, the energy need to be supplied somewhere, which makes so
 necessary. To connect a source in the oemof logic, there needs to be a *oemof.solph.Bus* to which
 the source is connected. The two files *bus.csv* and *source.csv* need to be provided:
 
-.. include:: ../dhnx/optimization/add_components.py
+.. include:: ../src/dhnx/optimization/add_components.py
   :start-after: .. _bus_table:
   :end-before: Parameters
 

--- a/src/dhnx/input_output.py
+++ b/src/dhnx/input_output.py
@@ -489,7 +489,7 @@ def load_invest_options(path):
 
     .. _folder_structure_invest:
 
-    .. code-block:: txt
+    .. code-block:: text
 
         tree
         ├── network

--- a/src/dhnx/optimization/oemof_heatpipe.py
+++ b/src/dhnx/optimization/oemof_heatpipe.py
@@ -58,7 +58,7 @@ class HeatPipeline(Node):
      * :py:class:`~dhnx.optimization.oemof_heatpipe.HeatPipelineBlock` (if no
        Investment object present)
      * :py:class:`~dhnx.optimization.oemof_heatpipe.HeatPipelineInvestBlock`
-      (ifInvestment object present)
+       (if Investment object present)
 
     Examples
     --------


### PR DESCRIPTION
The docs were not building for quite a while.

Fixed errors:
- Some errors about broken file paths resulted from moving the folder ./dhnx to ./src/dhnx
- One link caused ``415 Client Error: Unsupported Media Type for url``, despite working in a browser (https://www.schweizer-fn.de/stroemung/rauhigkeit/rauhigkeit.php). Check is now ignored.

Fixed warnings:
- The logs also show ``WARNING: LaTeX command 'latex' cannot be run (needed for math display), check the imgmath_latex setting`` and equations were indeed broken in my local test. Switching the equation rendering to MathJax solved it for me.
- ``WARNING: Pygments lexer name 'txt' is not known [misc.highlighting_failure]``: Change ``code-block:: txt`` to ``code-block:: text``