### PR TITLE
Adapt to API changes in oemof.solph 0.6.2

### DIFF
--- a/docs/whatsnew/v0-1-0.rst
+++ b/docs/whatsnew/v0-1-0.rst
@@ -5,7 +5,12 @@
 API changes
 ^^^^^^^^^^^^^^^^^^^^
 
-* No changes
+* Adapt to oemof.solph 0.6.2
+
+  * Flow parameters ``min`` and ``max`` have been renamed to ``minimum`` and
+    ``maximum`` in oemof.solph
+  * ``min`` and ``max`` are still usable in dhnx, but will trigger an oemof
+    deprecation warning. Use ``minimum`` and ``maximum`` instead
 
 
 New features
@@ -51,3 +56,4 @@ Contributors
 ^^^^^^^^^^^^^^^^^^^^
 
 * Patrik Schönfeldt (DLR)
+* Joris Zimmermann (siz energieplus)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     'pillow',
     'folium',
     'addict',
-    'oemof.solph >= 0.6',
+    'oemof.solph >= 0.6.2',
     'scipy >= 1.5',
 ]
 license = "MIT"

--- a/src/dhnx/optimization/add_components.py
+++ b/src/dhnx/optimization/add_components.py
@@ -465,7 +465,7 @@ def add_heatpipes(it, labels, bidirectional, length, b_in, b_out, nodes):
 
         # bidirectional heatpipelines yes or no
         flow_bi_args = (
-            {"bidirectional": True, "min": -1} if bidirectional else {}
+            {"minimum": -1} if bidirectional else {}
         )
 
         nodes.append(
@@ -535,7 +535,7 @@ def add_heatpipes_exist(pipes, labels, gd, q, b_in, b_out, nodes):
     hlff = t["l_factor_fix"] * q["length"]
 
     flow_bi_args = (
-        {"bidirectional": True, "min": -1} if gd["bidirectional_pipes"] else {}
+        {"minimum": -1} if gd["bidirectional_pipes"] else {}
     )
 
     outflow_args = {"nonconvex": solph.NonConvex()} if t["nonconvex"] else {}

--- a/src/dhnx/optimization/optimization_models.py
+++ b/src/dhnx/optimization/optimization_models.py
@@ -70,7 +70,7 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
         Attribute, which will be the oemof.solph.Model for optimisation.
     oemof_flow_attr : set
         Possible flow attributes, which can be used additionally:
-        {'nominal_capacity', 'min', 'max', 'variable_costs', 'fix'}
+        {'nominal_capacity', 'minimum', 'maximum', 'variable_costs', 'fix'}
     results : dict
         Empty dictionary for the results.
 
@@ -102,8 +102,10 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
         # list of possible oemof flow attributes, e.g. for producers source
         self.oemof_flow_attr = {
             "nominal_capacity",
-            "min",
-            "max",
+            "min",  # deprecated since oemof.solph 0.6.2
+            "minimum",
+            "max",  # deprecated since oemof.solph 0.6.2
+            "maximum",
             "variable_costs",
             "fix",
         }


### PR DESCRIPTION
There are some deprecations by oemof.solph 0.6.2 that can be fixed.

- Flow parameters ``min`` and ``max`` have been renamed to ``minimum`` and ``maximum``. 
- Parameter ``bidirectional`` is deprecated and thus removed (``minimum = -1`` still allows bidirectional flow).

With this change, ``min`` and ``max`` are still allowed to be set by the user and will trigger an oemof deprecation warning,
but users can use the renamed parameters to get rid of the warning.

The remaining ``min`` and ``max`` can be removed once they are completely dropped by oemof.solph.

- [x] Update code
- [x] Update dependencies to oemof.solph 0.6.2 (from 0.6)
- [x] Update changelog