### PR TITLE
Remove LaTeX installation from tox_checks workflow

### DIFF
--- a/.github/workflows/tox_checks.yml
+++ b/.github/workflows/tox_checks.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Update package list
         run: sudo apt update
-      - name: Install LaTeX
-        run: sudo apt install dvipng rubber texlive-latex-extra
       - name: Git clone
         uses: actions/checkout@v7
 


### PR DESCRIPTION
The LaTeX installation step seems to take a longer time in the workflows.
In e9b33a45bae86e4048017bd3ee2664e1ac81847f I removed, as far as I understand, the dependency on LaTeX to build the documentation.

I am testing the workflows without this installation instruction.

All tests are passing, so it seems fine to me. Locally on my machine, docs are also building without LaTeX installed and equations are rendering correctly.