### PR TITLE
Replace optional dependency warning prints

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,4 +8,5 @@ Authors
 * Joris Zimmermann
 * Marie-Claire Gering
 * oakca
+* Patrik Schönfeldt
 * Robert Valeske

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ License
 
 MIT License
 
-Copyright (c) 2020 oemof developing group
+Copyright (c) oemof developing group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/whatsnew/v0-1-0.rst
+++ b/docs/whatsnew/v0-1-0.rst
@@ -53,7 +53,7 @@ API changes
 New features
 ^^^^^^^^^^^^^^^^^^^^
 
-* No changes
+* Improved handling of optional dependencies.
 
 New components/constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/dhnx/dhn_from_osm.py
+++ b/src/dhnx/dhn_from_osm.py
@@ -11,19 +11,13 @@ available from its original location:
 SPDX-License-Identifier: MIT
 """
 
-from dhnx.helpers import OptionalDependencyPlaceholder
-
-try:
-    import geopandas as gpd
-except ImportError:
-    gpd = OptionalDependencyPlaceholder("geopandas", "process osm data")
-
 import pandas as pd
 
-try:
-    import shapely
-except ImportError:
-    shapely = OptionalDependencyPlaceholder("shapely", "process geometry")
+from dhnx.helpers import import_optional_dependency
+
+gpd = import_optional_dependency("geopandas", "process osm data")
+shapely = import_optional_dependency("shapely", "process geometry")
+
 
 def connect_points_to_network(points, nodes, edges):
     r"""
@@ -74,7 +68,9 @@ def connect_points_to_network(points, nodes, edges):
         n_nearest_points.append([id_nearest_point, nearest_point])
 
         n_edges.append(
-            [id_point, id_nearest_point, shapely.geometry.LineString([point, nearest_point])]
+            [id_point, id_nearest_point, shapely.geometry.LineString(
+                [point, nearest_point]
+            )]
         )
 
     n_points = gpd.GeoDataFrame(

--- a/src/dhnx/dhn_from_osm.py
+++ b/src/dhnx/dhn_from_osm.py
@@ -11,21 +11,19 @@ available from its original location:
 SPDX-License-Identifier: MIT
 """
 
+from dhnx.helpers import OptionalDependencyPlaceholder
+
 try:
     import geopandas as gpd
-
 except ImportError:
-    print("Need to install geopandas to process osm data.")
+    gpd = OptionalDependencyPlaceholder("geopandas", "process osm data")
 
 import pandas as pd
 
 try:
-    from shapely.geometry import LineString
-    from shapely.ops import nearest_points
-
+    import shapely
 except ImportError:
-    print("Need to install shapely to download from osm.")
-
+    shapely = OptionalDependencyPlaceholder("shapely", "process geometry")
 
 def connect_points_to_network(points, nodes, edges):
     r"""
@@ -69,14 +67,14 @@ def connect_points_to_network(points, nodes, edges):
 
         id_point = len_nodes + len_points + i
 
-        nearest_point = nearest_points(edges_united, point)[0]
+        nearest_point = shapely.ops.nearest_points(edges_united, point)[0]
 
         n_points.append([id_point, point])
 
         n_nearest_points.append([id_nearest_point, nearest_point])
 
         n_edges.append(
-            [id_point, id_nearest_point, LineString([point, nearest_point])]
+            [id_point, id_nearest_point, shapely.geometry.LineString([point, nearest_point])]
         )
 
     n_points = gpd.GeoDataFrame(

--- a/src/dhnx/gistools/connect_points.py
+++ b/src/dhnx/gistools/connect_points.py
@@ -13,20 +13,19 @@ This module is not fully tested yet, so use it with care.
 
 SPDX-License-Identifier: MIT
 """
+from dhnx.helpers import OptionalDependencyPlaceholder
+
 try:
     import geopandas as gpd
-
 except ImportError:
-    print("Need to install geopandas to process geometry data.")
+    gpd = OptionalDependencyPlaceholder("geopandas", "process osm data")
 
 try:
-    from shapely.geometry import LineString
-    from shapely.geometry import MultiPoint
-    from shapely.geometry import Point
-    from shapely.ops import nearest_points
-    from shapely.ops import unary_union
+    from shapely import geometry
+    from shapely import ops as shapely_ops
 except ImportError:
-    print("Need to install shapely to process geometry.")
+    geometry = OptionalDependencyPlaceholder("shapely", "process geometry")
+    shapely_ops = OptionalDependencyPlaceholder("shapely", "process geometry")
 
 import logging
 import warnings
@@ -92,8 +91,8 @@ def calc_lot_foot(line, point):
     -------
     shapely.geometry.Point
     """
-    s_1 = Point(line.coords[0])
-    s_2 = Point(line.coords[-1])
+    s_1 = geometry.Point(line.coords[0])
+    s_2 = geometry.Point(line.coords[-1])
 
     g_1 = point_to_array(s_1)  # end point 1 of line
     g_2 = point_to_array(s_2)  # end point 2 of line
@@ -106,12 +105,12 @@ def calc_lot_foot(line, point):
     x_0 = g_1  # point on line
 
     y = x_1 - (np.dot((x_1 - x_0), n) / np.dot(n, n)) * n
-    lot_foot_point = Point(y[0], y[1])
+    lot_foot_point = geometry.Point(y[0], y[1])
 
     # # alternative generation via intersection
     # # (=> intersections point is not exaclty on lines as well)
     # y = x_1 - 2*(np.dot((x_1 - x_0), n)/np.dot(n, n)) * n
-    # lot_line = LineString([(y[0], y[1]), (x_1[0], x_1[1])])
+    # lot_line = geometry.LineString([(y[0], y[1]), (x_1[0], x_1[1])])
     # lot_foot_point = lot_line.intersection(line)
 
     return lot_foot_point
@@ -179,8 +178,10 @@ def create_object_connections(
 
     def create_object_connection(point_geom, lines, tol_distance=tol_distance):
         # Find the nearest line and its nearest point
-        lines_merged = unary_union(lines.geometry)
-        nearest_line_point = nearest_points(point_geom, lines_merged)[1]
+        lines_merged = shapely_ops.unary_union(lines.geometry)
+        nearest_line_point = shapely_ops.nearest_points(
+            point_geom, lines_merged
+        )[1]
         nearest_line_idx = lines[
             nearest_line_point.distance(lines.geometry) < 1e-8
         ].index
@@ -196,7 +197,7 @@ def create_object_connections(
             # Check if the distance of nearest_point_on_line is close
             # to an existing point on the line
             points_on_line = nearest_line.boundary
-            closest_existing_point = nearest_points(
+            closest_existing_point = shapely_ops.nearest_points(
                 nearest_line_point, points_on_line
             )[1]
             dist_on_line = nearest_line_point.distance(closest_existing_point)
@@ -212,7 +213,7 @@ def create_object_connections(
                 connection_point = nearest_line_point
 
         # Create connection line (Direction: From street to building)
-        conn_line = LineString([connection_point, point_geom])
+        conn_line = geometry.LineString([connection_point, point_geom])
         return conn_line, nearest_line_idx
 
     conn_lines_list = []
@@ -235,12 +236,12 @@ def create_object_connections(
                 # line to find a more relevant alternative
                 neighbours = lines[
                     lines.touches(
-                        unary_union(lines.geometry[nearest_line_idx])
+                        shapely_ops.unary_union(lines.geometry[nearest_line_idx])
                     )
                 ]
                 lines_drop.extend(neighbours.index)
                 neighbours2 = lines[
-                    lines.touches(unary_union(neighbours.geometry))
+                    lines.touches(shapely_ops.unary_union(neighbours.geometry))
                 ]
                 lines_drop.extend(neighbours2.index)
 
@@ -284,8 +285,8 @@ def create_object_connections(
                         gpd.GeoDataFrame(lines, crs=lines.crs),
                         gpd.GeoDataFrame(
                             geometry=[
-                                LineString([line_start, conn_point]),
-                                LineString([conn_point, line_end]),
+                                geometry.LineString([line_start, conn_point]),
+                                geometry.LineString([conn_point, line_end]),
                             ],
                             crs=lines.crs,
                             data=pd.concat([attributes, attributes]),
@@ -436,7 +437,7 @@ def run_point_method_boundary(consumers_poly, consumers, lines_consumers):
     # Only keep the new consumer lines if they have a useful minimum length.
     # There was an edgecase where a street 'almost' touched a building,
     # and the cut consumer line had a length of 1e-9 m
-    lines_consumers_n[lines_consumers_n.length < 1e-3] = LineString()
+    lines_consumers_n[lines_consumers_n.length < 1e-3] = geometry.LineString()
 
     # Now the "consumers" (point objects for each building) need to be
     # updated to touch the end of the consumer_lines
@@ -497,7 +498,7 @@ def run_point_method_boundary(consumers_poly, consumers, lines_consumers):
     consumers_n = (
         pd.DataFrame(consumers_n)  # convert gdf to df
         .groupby("id_full", sort=False, as_index=False)
-        .agg(lambda x: MultiPoint(x.values))  # returns df
+        .agg(lambda x: geometry.MultiPoint(x.values))  # returns df
         .set_geometry(
             consumers_n.geometry.name, crs=consumers_n.crs
         )  # convert to gdf
@@ -563,7 +564,7 @@ def process_geometry(
     Parameters
     ----------
     lines : geopandas.GeoDataFrame
-        Potential routes for the DHS. Expected geometry Linestrings or
+        Potential routes for the DHS. Expected geometry LineStrings or
         MultilineStrings. The graph of this line network should be connected.
     consumers : geopandas.GeoDataFrame
         Location of demand/consumers. Expected geometry: Polygons or Points.

--- a/src/dhnx/gistools/connect_points.py
+++ b/src/dhnx/gistools/connect_points.py
@@ -13,19 +13,6 @@ This module is not fully tested yet, so use it with care.
 
 SPDX-License-Identifier: MIT
 """
-from dhnx.helpers import OptionalDependencyPlaceholder
-
-try:
-    import geopandas as gpd
-except ImportError:
-    gpd = OptionalDependencyPlaceholder("geopandas", "process osm data")
-
-try:
-    from shapely import geometry
-    from shapely import ops as shapely_ops
-except ImportError:
-    geometry = OptionalDependencyPlaceholder("shapely", "process geometry")
-    shapely_ops = OptionalDependencyPlaceholder("shapely", "process geometry")
 
 import logging
 import warnings
@@ -33,7 +20,13 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from dhnx.helpers import import_optional_dependency
+
 from . import geometry_operations as go
+
+gpd = import_optional_dependency("geopandas", "process osm data")
+geometry = import_optional_dependency("shapely.geometry", "process geometry")
+shapely_ops = import_optional_dependency("shapely.ops", "process geometry")
 
 logger = logging.getLogger(__name__)  # Create a logger for this module
 
@@ -236,7 +229,9 @@ def create_object_connections(
                 # line to find a more relevant alternative
                 neighbours = lines[
                     lines.touches(
-                        shapely_ops.unary_union(lines.geometry[nearest_line_idx])
+                        shapely_ops.unary_union(
+                            lines.geometry[nearest_line_idx]
+                        )
                     )
                 ]
                 lines_drop.extend(neighbours.index)

--- a/src/dhnx/gistools/geometry_operations.py
+++ b/src/dhnx/gistools/geometry_operations.py
@@ -15,23 +15,19 @@ SPDX-License-Identifier: MIT
 
 import math
 
+from dhnx.helpers import OptionalDependencyPlaceholder
+
 try:
     import geopandas as gpd
 except ImportError:
-    print("Need to install geopandas to process geometry data.")
+    gpd = OptionalDependencyPlaceholder("geopandas", "process osm data")
 
 import networkx as nx
 
 try:
     import shapely
-    from shapely import wkt
-    from shapely.geometry import LineString
-    from shapely.geometry import Point
-    from shapely.geometry import mapping
-    from shapely.ops import nearest_points
-    from shapely.ops import unary_union
 except ImportError:
-    print("Need to install shapely to process geometry.")
+    shapely = OptionalDependencyPlaceholder("shapely", "process geometry")
 
 import logging
 
@@ -59,12 +55,13 @@ def create_forks(lines):
     geopandas.GeoDataFrame : GeoDataFrame with Points as geometry.
 
     """
+
     nodes = gpd.GeoDataFrame(geometry=[], crs=lines.crs)
 
     for _, j in lines.iterrows():
         geom = j["geometry"]
-        p_0 = Point(geom.boundary.geoms[0])
-        p_1 = Point(geom.boundary.geoms[-1])
+        p_0 = shapely.geometry.Point(geom.boundary.geoms[0])
+        p_1 = shapely.geometry.Point(geom.boundary.geoms[-1])
         nodes = pd.concat(
             [nodes, gpd.GeoDataFrame(geometry=[p_0, p_1], crs=lines.crs)],
             ignore_index=True,
@@ -78,7 +75,7 @@ def create_forks(lines):
 
     # create shapely geometry again
     nodes["geometry"] = nodes["geometry_wkt"].apply(
-        lambda geom: wkt.loads(geom)
+        lambda geom: shapely.wkt.loads(geom)
     )  # pylint: disable=unnecessary-lambda
 
     # set index for forks
@@ -108,16 +105,20 @@ def insert_node_ids(lines, nodes):
     geopandas.GeoDataFrame
     """
     nodes["geo_wkt"] = nodes.geometry.apply(
-        lambda x: wkt.dumps(x, output_dimension=2)
+        lambda x: shapely.wkt.dumps(x, output_dimension=2)
     )
     nodes.set_index("geo_wkt", drop=True, inplace=True)
 
     # add id to gdf_lines for starting and ending node point as wkt
     lines["b0_wkt"] = lines.geometry.apply(
-        lambda geom: wkt.dumps(geom.boundary.geoms[0], output_dimension=2)
+        lambda geom: shapely.wkt.dumps(
+            geom.boundary.geoms[0], output_dimension=2
+        )
     )
     lines["b1_wkt"] = lines.geometry.apply(
-        lambda geom: wkt.dumps(geom.boundary.geoms[-1], output_dimension=2)
+        lambda geom: shapely.wkt.dumps(
+            geom.boundary.geoms[-1], output_dimension=2
+        )
     )
 
     def match_multipoint(point_wkt):
@@ -127,9 +128,9 @@ def insert_node_ids(lines, nodes):
         result from multiple connection lines, and not only single Point
         objects.
         """
-        point_line = wkt.loads(point_wkt)
+        point_line = shapely.wkt.loads(point_wkt)
         for point_node in nodes.index:
-            if point_line.within(wkt.loads(point_node)):
+            if point_line.within(shapely.wkt.loads(point_node)):
                 return nodes.loc[point_node, "id_full"]
         logger.error("Point not found: %s", point_wkt)
         return False
@@ -141,10 +142,16 @@ def insert_node_ids(lines, nodes):
         lines["to_node"] = lines["b1_wkt"].apply(lambda x: match_multipoint(x))
     except KeyError as e:
         errors = [
-            wkt.loads(x) for x in lines["b0_wkt"] if x not in nodes["id_full"]
+            shapely.wkt.loads(x)
+            for x in lines["b0_wkt"]
+            if x not in nodes["id_full"]
         ]
         errors.extend(
-            [wkt.loads(x) for x in lines["b1_wkt"] if not match_multipoint(x)]
+            [
+                shapely.wkt.loads(x)
+                for x in lines["b1_wkt"]
+                if not match_multipoint(x)
+            ]
         )
         gdf_errors = gpd.GeoDataFrame(geometry=errors, crs=lines.crs)
         ax = lines.plot(color='blue')
@@ -198,10 +205,10 @@ def check_double_points(gdf, radius=0.001, id_column=None):
         point = c["geometry"]
         gdf_other = gdf.drop([r])
         # Prevent OSError, see https://github.com/oemof/DHNx/issues/107
-        other_points = unary_union(list(gdf_other["geometry"]))
+        other_points = shapely.ops.unary_union(list(gdf_other["geometry"]))
 
         # x1 = nearest_points(point, other_points)[0]
-        x2 = nearest_points(point, other_points)[1]
+        x2 = shapely.ops.nearest_points(point, other_points)[1]
 
         if point.distance(x2) <= radius:
             l_ids.append(r)
@@ -269,8 +276,8 @@ def split_multilinestr_to_linestr(gdf_input):
 
             multilinestrings = []
 
-            for line in mapping(geom)["coordinates"]:
-                multilinestrings.append(LineString(line))
+            for line in shapely.geometry.mapping(geom)["coordinates"]:
+                multilinestrings.append(shapely.geometry.LineString(line))
 
             for multiline in multilinestrings:
                 new_row = b.copy()
@@ -301,7 +308,7 @@ def split_multilinestr_to_linestr(gdf_input):
 
             for num in range(num_new_lines):
                 new_row = b.copy()
-                new_row["geometry"] = LineString(
+                new_row["geometry"] = shapely.geometry.LineString(
                     [geom.coords[num], geom.coords[num + 1]]
                 )
                 new_lines = pd.concat(
@@ -324,7 +331,7 @@ def split_multilinestr_to_linestr(gdf_input):
 def _line_string(
     path_edges: list,
     lines_all: gpd.GeoDataFrame,
-) -> LineString:
+) -> shapely.geometry.LineString:
     """
     Create a LineString from a list of 2-tuples of node names,
     combined from LineStrings found in lines_all.
@@ -368,7 +375,7 @@ def _line_string(
 
         last_segment = segment
 
-    return LineString(ordered)
+    return shapely.geometry.LineString(ordered)
 
 
 def simplify(

--- a/src/dhnx/gistools/geometry_operations.py
+++ b/src/dhnx/gistools/geometry_operations.py
@@ -13,26 +13,18 @@ This module is not fully tested yet, so use it with care.
 SPDX-License-Identifier: MIT
 """
 
-import math
-
-from dhnx.helpers import OptionalDependencyPlaceholder
-
-try:
-    import geopandas as gpd
-except ImportError:
-    gpd = OptionalDependencyPlaceholder("geopandas", "process osm data")
-
-import networkx as nx
-
-try:
-    import shapely
-except ImportError:
-    shapely = OptionalDependencyPlaceholder("shapely", "process geometry")
 
 import logging
+import math
 
 import matplotlib.pyplot as plt
+import networkx as nx
 import pandas as pd
+
+from dhnx.helpers import import_optional_dependency
+
+shapely = import_optional_dependency("shapely", "process geometry")
+gpd = import_optional_dependency("geopandas", "process osm data")
 
 logger = logging.getLogger(__name__)  # Create a logger for this module
 

--- a/src/dhnx/helpers.py
+++ b/src/dhnx/helpers.py
@@ -20,3 +20,18 @@ def sum_ignore_none(*items):
         sum_ignoring_none = None
 
     return sum_ignoring_none
+
+
+class OptionalDependencyPlaceholder:
+    def __init__(
+        self,
+        module_name: str,
+        functionality: str,
+    ):
+        self._functionality = functionality
+        self._module_name = module_name
+
+    def __getattr__(self, name):
+        raise ModuleNotFoundError(
+            f"Need to install {self._module_name} to {self._functionality}."
+        )

--- a/src/dhnx/helpers.py
+++ b/src/dhnx/helpers.py
@@ -26,6 +26,7 @@ def sum_ignore_none(*items):
 
 
 class OptionalDependencyPlaceholder:
+    """Class to delay ImportErrors for optional dependencies"""
     def __init__(
         self,
         module_name: str,
@@ -37,7 +38,7 @@ class OptionalDependencyPlaceholder:
         self._original_error = original_error
 
     def __getattr__(self, _):
-        raise ModuleNotFoundError(
+        raise ImportError(
             f"Need {self._module_name} to {self._functionality},"
             + f" but {self._original_error}."
         )
@@ -47,6 +48,11 @@ def import_optional_dependency(
     name: str,
     functionality: str,
 ) -> types.ModuleType:
+    """Import wrapper for optional dependencies.
+
+    If possible, it will just import the module.
+    Otherwise, it returns a placeholder so that the ImportError is not risen
+    on import but only if the optional dependency is acutally used."""
     try:
         module = importlib.import_module(name)
     except ImportError as err:

--- a/src/dhnx/helpers.py
+++ b/src/dhnx/helpers.py
@@ -1,3 +1,6 @@
+import importlib
+import types
+
 import addict
 
 
@@ -27,11 +30,27 @@ class OptionalDependencyPlaceholder:
         self,
         module_name: str,
         functionality: str,
+        original_error: str,
     ):
         self._functionality = functionality
         self._module_name = module_name
+        self._original_error = original_error
 
-    def __getattr__(self, name):
+    def __getattr__(self, _):
         raise ModuleNotFoundError(
-            f"Need to install {self._module_name} to {self._functionality}."
+            f"Need {self._module_name} to {self._functionality},"
+            + f" but {self._original_error}."
         )
+
+
+def import_optional_dependency(
+    name: str,
+    functionality: str,
+) -> types.ModuleType:
+    try:
+        module = importlib.import_module(name)
+    except ImportError as err:
+        module = OptionalDependencyPlaceholder(
+            name, functionality, original_error=err
+        )
+    return module

--- a/src/dhnx/input_output.py
+++ b/src/dhnx/input_output.py
@@ -19,24 +19,27 @@ import numpy as np
 import pandas as pd
 from addict import Dict
 
-try:
-    from shapely.geometry import LineString
-    from shapely.geometry import Point
+from dhnx.helpers import OptionalDependencyPlaceholder
 
+try:
+    from shapely import geometry
 except ImportError:
-    print("Need to install shapely to download from osm.")
+    geometry = OptionalDependencyPlaceholder("shapely", "process geometry")
 
 try:
     import geopandas as gpd
-
 except ImportError:
-    print("Need to install geopandas to download from osm.")
+    gpd = OptionalDependencyPlaceholder(
+        "geopandas", "process osm data"
+    )
 
 try:
     import osmnx as ox
-
 except ImportError:
-    print("Need to install osmnx to download from osm.")
+    ox = OptionalDependencyPlaceholder(
+        "osmnx", "download from osm"
+    )
+
 
 from dhnx.dhn_from_osm import connect_points_to_network
 
@@ -305,7 +308,7 @@ class OSMNetworkImporter(NetworkImporter):
             gdf_nodes = gpd.GeoDataFrame(list(data), index=nodes)
             if node_geometry:
                 gdf_nodes["geometry"] = gdf_nodes.apply(
-                    lambda row: Point(row["x"], row["y"]), axis=1
+                    lambda row: geometry.Point(row["x"], row["y"]), axis=1
                 )
                 gdf_nodes.set_geometry("geometry", inplace=True)
             gdf_nodes.crs = G.graph["crs"]
@@ -330,10 +333,10 @@ class OSMNetworkImporter(NetworkImporter):
                 # create one now if fill_edge_geometry==True
                 if "geometry" not in data:
                     if fill_edge_geometry:
-                        point_u = Point((G.nodes[u]["x"], G.nodes[u]["y"]))
-                        point_v = Point((G.nodes[v]["x"], G.nodes[v]["y"]))
-                        edge_details["geometry"] = LineString(
-                            [point_u, point_v]
+                        geometry.Point_u = geometry.Point((G.nodes[u]["x"], G.nodes[u]["y"]))
+                        geometry.Point_v = geometry.Point((G.nodes[v]["x"], G.nodes[v]["y"]))
+                        edge_details["geometry"] = geometry.LineString(
+                            [point_u, geometry.Point_v]
                         )
                     else:
                         edge_details["geometry"] = np.nan

--- a/src/dhnx/input_output.py
+++ b/src/dhnx/input_output.py
@@ -19,29 +19,12 @@ import numpy as np
 import pandas as pd
 from addict import Dict
 
-from dhnx.helpers import OptionalDependencyPlaceholder
-
-try:
-    from shapely import geometry
-except ImportError:
-    geometry = OptionalDependencyPlaceholder("shapely", "process geometry")
-
-try:
-    import geopandas as gpd
-except ImportError:
-    gpd = OptionalDependencyPlaceholder(
-        "geopandas", "process osm data"
-    )
-
-try:
-    import osmnx as ox
-except ImportError:
-    ox = OptionalDependencyPlaceholder(
-        "osmnx", "download from osm"
-    )
-
-
 from dhnx.dhn_from_osm import connect_points_to_network
+from dhnx.helpers import import_optional_dependency
+
+geometry = import_optional_dependency("shapely.geometry", "process geometry")
+gpd = import_optional_dependency("geopandas", "process osm data")
+ox = import_optional_dependency("osmnx", "download from osm")
 
 logger = logging.getLogger()
 
@@ -333,10 +316,14 @@ class OSMNetworkImporter(NetworkImporter):
                 # create one now if fill_edge_geometry==True
                 if "geometry" not in data:
                     if fill_edge_geometry:
-                        geometry.Point_u = geometry.Point((G.nodes[u]["x"], G.nodes[u]["y"]))
-                        geometry.Point_v = geometry.Point((G.nodes[v]["x"], G.nodes[v]["y"]))
+                        point_u = geometry.Point(
+                            (G.nodes[u]["x"], G.nodes[u]["y"])
+                        )
+                        point_v = geometry.Point(
+                            (G.nodes[v]["x"], G.nodes[v]["y"])
+                        )
                         edge_details["geometry"] = geometry.LineString(
-                            [point_u, geometry.Point_v]
+                            [point_u, point_v]
                         )
                     else:
                         edge_details["geometry"] = np.nan

--- a/src/dhnx/optimization/precalc_hydraulic.py
+++ b/src/dhnx/optimization/precalc_hydraulic.py
@@ -30,6 +30,9 @@ from dhnx.helpers import import_optional_dependency
 CoolProp = import_optional_dependency(
     "CoolProp.CoolProp", "use the hydraulic pre-calculation module"
 )
+pp = import_optional_dependency(
+    "pandapipes", "use pandapipes pressure loss calculations"
+)
 
 logger = logging.getLogger(__name__)  # Create a logger for this module
 
@@ -532,7 +535,6 @@ def delta_p_pandapipes(
     -------
     Pressure drop [Pa] : numeric
     """
-    import pandapipes as pp
 
     p_bar = pressure / 1e5  # Pa to bar
     tfluid_k = T_medium + 273.15

--- a/src/dhnx/optimization/precalc_hydraulic.py
+++ b/src/dhnx/optimization/precalc_hydraulic.py
@@ -25,15 +25,11 @@ import math
 import numpy as np
 from scipy.optimize import fsolve
 
-from dhnx.helpers import OptionalDependencyPlaceholder
+from dhnx.helpers import import_optional_dependency
 
-try:
-    from CoolProp import CoolProp
-except ImportError:
-    CoolProp = OptionalDependencyPlaceholder(
-        module_name="CoolProp",
-        functionality="use the hydraulic pre-calculation module"
-    )
+CoolProp = import_optional_dependency(
+    "CoolProp.CoolProp", "use the hydraulic pre-calculation module"
+)
 
 logger = logging.getLogger(__name__)  # Create a logger for this module
 
@@ -1008,7 +1004,9 @@ def calc_v_mf(mf, di, T_av, p=101325):
     flow velocity [m/s]: numeric
 
     """
-    rho = CoolProp.PropsSI("D", "T", T_av + 273.15, "P", p, "IF97::Water")  # [kg/m^3]
+    rho = CoolProp.PropsSI(
+        "D", "T", T_av + 273.15, "P", p, "IF97::Water"
+    )  # kg/m^3
 
     return mf / (rho * (0.5 * di) ** 2 * math.pi)
 

--- a/src/dhnx/optimization/precalc_hydraulic.py
+++ b/src/dhnx/optimization/precalc_hydraulic.py
@@ -25,13 +25,14 @@ import math
 import numpy as np
 from scipy.optimize import fsolve
 
-try:
-    from CoolProp.CoolProp import PropsSI
+from dhnx.helpers import OptionalDependencyPlaceholder
 
+try:
+    from CoolProp import CoolProp
 except ImportError:
-    print(
-        "Need to install CoolProp to use the hydraulic "
-        "pre-calculation module."
+    CoolProp = OptionalDependencyPlaceholder(
+        module_name="CoolProp",
+        functionality="use the hydraulic pre-calculation module"
     )
 
 logger = logging.getLogger(__name__)  # Create a logger for this module
@@ -446,9 +447,9 @@ def delta_p_internal(
     k = k * 0.001
 
     # get density of water [kg/m^3]
-    d = PropsSI("D", "T", T_medium + 273.15, "P", pressure, fluid)
+    d = CoolProp.PropsSI("D", "T", T_medium + 273.15, "P", pressure, fluid)
     # dynamic viscosity eta [kg/(m*s)]
-    d_v = PropsSI("V", "T", T_medium + 273.15, "P", pressure, fluid)
+    d_v = CoolProp.PropsSI("V", "T", T_medium + 273.15, "P", pressure, fluid)
     k_v = calc_k_v(d_v, d)
 
     # Reynolds number
@@ -905,9 +906,9 @@ def calc_power(T_vl=80, T_rl=50, mf=3, p=101325):
     thermal power [W] : numeric
 
     """
-    cp_vl = PropsSI("C", "T", T_vl + 273.15, "P", p, "IF97::Water")
+    cp_vl = CoolProp.PropsSI("C", "T", T_vl + 273.15, "P", p, "IF97::Water")
 
-    cp_rl = PropsSI("C", "T", T_rl + 273.15, "P", p, "IF97::Water")
+    cp_rl = CoolProp.PropsSI("C", "T", T_rl + 273.15, "P", p, "IF97::Water")
 
     return mf * (cp_vl * (T_vl + 273.15) - cp_rl * (T_rl + 273.15))
 
@@ -941,7 +942,7 @@ def calc_mass_flow(v, di, T_av, p=101325):
     mass flow [kg/s] : numeric
 
     """
-    rho = PropsSI("D", "T", T_av + 273.15, "P", p, "IF97::Water")
+    rho = CoolProp.PropsSI("D", "T", T_av + 273.15, "P", p, "IF97::Water")
 
     return rho * v * (0.5 * di) ** 2 * math.pi
 
@@ -974,7 +975,7 @@ def calc_mass_flow_P(P, T_av, delta_T, p=101325):
     mass flow [kg/s]: numeric
 
     """
-    cp = PropsSI("C", "T", T_av + 273.15, "P", p, "IF97::Water")
+    cp = CoolProp.PropsSI("C", "T", T_av + 273.15, "P", p, "IF97::Water")
 
     return P / (cp * delta_T)
 
@@ -1007,7 +1008,7 @@ def calc_v_mf(mf, di, T_av, p=101325):
     flow velocity [m/s]: numeric
 
     """
-    rho = PropsSI("D", "T", T_av + 273.15, "P", p, "IF97::Water")  # [kg/m^3]
+    rho = CoolProp.PropsSI("D", "T", T_av + 273.15, "P", p, "IF97::Water")  # [kg/m^3]
 
     return mf / (rho * (0.5 * di) ** 2 * math.pi)
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -191,7 +191,7 @@ def test_optimization_example_02():
         consumers=gdf_cons,
         method="boundary",
         reset_index=True,
-        welding=True,  # Instead of 'simplify', just to trigger FutureWarning
+        simplify=True,  # Instead of 'simplify', just to trigger FutureWarning
     )
 
     # initialize a ThermalNetwork

--- a/tests/test_optional_import_wrapper.py
+++ b/tests/test_optional_import_wrapper.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from dhnx.helpers import OptionalDependencyPlaceholder
+from dhnx.helpers import import_optional_dependency
+
+
+def test_optional_dependency_placeholder():
+    original_error = "original import error"
+    placeholder = OptionalDependencyPlaceholder(
+        "module_name",
+        "some functionality",
+        original_error,
+    )
+
+    with pytest.raises(ImportError, match=original_error):
+        placeholder.any_attribute
+
+
+def test_optional_dependency_import_wrapper():
+    non_existing_module_name = "non_existing_module"
+    placeholder = import_optional_dependency(
+        non_existing_module_name,
+        functionality="no functionality",
+    )
+
+    with pytest.raises(ImportError, match=non_existing_module_name):
+        placeholder.any_attribute


### PR DESCRIPTION
The idea behind the OptionalDependencyPlaceholder is that it raises an Error only once code asks for an attribute. To work with this approach, function and class imports had to be replaced by module imports.
